### PR TITLE
Allows tls passphrase, key, and cert to be null

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,9 +6,10 @@ module load_balancer {
   source = "./modules/sombra_load_balancers"
 
   # General Settings
-  deploy_env      = var.deploy_env
-  project_id      = var.project_id
-  alb_access_logs = var.alb_access_logs
+  override_alb_name = var.override_alb_name
+  deploy_env        = var.deploy_env
+  project_id        = var.project_id
+  alb_access_logs   = var.alb_access_logs
 
   # Ports and Firewall settings
   internal_port         = var.internal_port
@@ -111,7 +112,7 @@ module container_definition {
       SOMBRA_TLS_CERT           = var.tls_config.cert
     } :
     key => val
-    if length(val) > 0
+    if try(length(val) > 0, false)
   }
 
   deploy_env = var.deploy_env

--- a/modules/fargate_container_definition/main.tf
+++ b/modules/fargate_container_definition/main.tf
@@ -87,10 +87,10 @@ module "definition" {
   })
 
   environment = [
-    for name, value in var.environment :
+    for name in sort(keys(var.environment)):
     {
-      name  = name
-      value = value
+      name = name
+      value = var.environment[name]
     }
   ]
 

--- a/modules/sombra_load_balancers/single_alb.tf
+++ b/modules/sombra_load_balancers/single_alb.tf
@@ -2,6 +2,11 @@
 # Load Balancer #
 #################
 
+locals {
+  should_override_name = try(length(var.override_alb_name) > 0, false)
+  alb_name = local.should_override_name ? var.override_alb_name : "${var.project_id}-sombra-alb"
+}
+
 module load_balancer {
   source  = "terraform-aws-modules/alb/aws"
   version = "~> 5.0"
@@ -9,7 +14,7 @@ module load_balancer {
   create_lb = ! var.use_private_load_balancer
 
   # General Settings
-  name                       = "${var.project_id}-sombra-alb"
+  name                       = local.alb_name
   enable_deletion_protection = false
   access_logs                = var.alb_access_logs
 

--- a/modules/sombra_load_balancers/variables.tf
+++ b/modules/sombra_load_balancers/variables.tf
@@ -96,6 +96,12 @@ variable zone_id {
   description = "The ID of the Route53 hosted zone where the public sombra subdomain will be created"
 }
 
+variable override_alb_name {
+  type = string
+  default = null
+  description ="If set as a string, this custom name will be used on the alb resources"
+}
+
 variable tags {
   type        = map(string)
   description = "Tags to apply to all resources that support them"

--- a/variables.tf
+++ b/variables.tf
@@ -91,7 +91,26 @@ variable tls_config {
     cert       = string
     key        = string
   })
-  description = "Sombra TLS Support. These values are sensitive."
+  default = {
+    passphrase = null
+    cert = null
+    key = null
+  }
+  description = <<EOF
+  Sombra TLS Support. These values are sensitive, and should be kept secret.
+
+  We support quite a few options for this:
+  - Not configuring TLS at all, by leaving this variable empty. This is not recommended,
+    but is the easiest to setup. If you choose to go this route, you will rely on the TLS termination
+    at the load balancer only, and your communication from the ALB -> sombra instances will be unencrypted
+    inside your VPC.
+  - Adding a cert and key without a passphrase. To do this, add your cert and key here (as base64 encoded values)
+    and set the passphrase to either `null` or the empty string. This approach works well for those using the
+    `tls` terraform provider for generating certs.
+  - Adding a cert with an encoded key with the passphrase to unlock it. To do this, you'll need to manage the certs
+    fully on your own, but you can add the certs here as base64 encoded values (passphrase in plaintext). 
+    This is how we recommend you manage your TLS support.
+  EOF
 }
 
 ######################
@@ -334,6 +353,12 @@ variable use_private_load_balancer {
   or if you want to set up VPC Peering from your backend to the VPC that holds
   the Sombra load balancers.
   EOF
+}
+
+variable override_alb_name {
+  type = string
+  default = null
+  description ="If set as a string, this custom name will be used on the alb resources"
 }
 
 variable tags {


### PR DESCRIPTION
Added documentation to the `tls_config` var for the different options sombra supports, and how to use them through this module.

Misc changes:
- sorted the container env values for nicer terraform plan output
- Allow hardcoding the alb name to prevent downtime on our single tenant sombra deploys for now