### PR TITLE
Removes the ability to set ENCRYPTED_SAAS_HTTP_METHODS

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,6 @@ module container_definition {
     TRANSCEND_URL               = var.transcend_backend_url
     TRANSCEND_CN                = var.transcend_certificate_common_name
     LOG_LEVEL                   = var.log_level
-    ENCRYPTED_SAAS_HTTP_METHODS = join(",", var.encrypted_saas_http_methods)
 
     # Global Settings
     ORGANIZATION_URI                    = var.organization_uri

--- a/variables.tf
+++ b/variables.tf
@@ -177,12 +177,6 @@ variable transcend_certificate_common_name {
   description = "Transcend's certificate Common NameTranscend's certificate Common Name"
 }
 
-variable encrypted_saas_http_methods {
-  default     = ["GET"]
-  type        = list(string)
-  description = "Whitelisted HTTP methods when probing a SaaS tool for valid auth credentials"
-}
-
 variable saml_config {
   type = object({
     entrypoint             = string


### PR DESCRIPTION
Noticed this was removed on https://github.com/transcend-io/main/pull/4421/files, however it was defaulting here. We want to remove this entirely since.

@dmattia can you help me release a new version?