### PR TITLE
Added output for ALB ARN suffix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -70,10 +70,10 @@ module container_definition {
     HMAC_NONCE_KEY_CYCLE      = var.hmac_nonce_key_cycle
     KEY_ENCRYPTION_BASE_CYCLE = var.key_encryption_base_cycle
 
-    NODE_ENV                    = "production"
-    TRANSCEND_URL               = var.transcend_backend_url
-    TRANSCEND_CN                = var.transcend_certificate_common_name
-    LOG_LEVEL                   = var.log_level
+    NODE_ENV      = "production"
+    TRANSCEND_URL = var.transcend_backend_url
+    TRANSCEND_CN  = var.transcend_certificate_common_name
+    LOG_LEVEL     = var.log_level
 
     # Global Settings
     ORGANIZATION_URI                    = var.organization_uri

--- a/modules/sombra_load_balancers/outputs.tf
+++ b/modules/sombra_load_balancers/outputs.tf
@@ -27,3 +27,8 @@ output external_listener_arn {
   value       = var.use_private_load_balancer ? module.external_load_balancer.https_listener_arns[0] : module.load_balancer.https_listener_arns[1]
   description = "ARN of the external sombra load balancer listener"
 }
+
+output arn_suffix {
+  value       = var.use_private_load_balancer ? "" : module.load_balancer.this_lb_arn_suffix
+  description = "Amazon Resource Name suffix for the load balancer. Only present in single alb configurations"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,12 +23,17 @@ output external_listener_arn {
   description = "ARN of the external sombra load balancer listener"
 }
 
+output lb_arn_suffix {
+  value       = module.load_balancer.arn_suffix
+  description = "Amazon Resource Name suffix for the load balancer. Only present in single alb configurations"
+}
+
 output "role_arn" {
   value       = module.service.role_arn
   description = "Arn of the task execution role"
 }
 
 output "policy_arns" {
-  value = module.service.policy_arns
+  value       = module.service.policy_arns
   description = "Amazon resource names of all policies set on the IAM Role execution task"
 }


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- https://github.com/transcend-io/main/issues/4773

## Description

Adds an output, containing the ARN suffix of the load balancer. This is helpful for adding monitoring to the ALB made in this module