### PR TITLE
Set default for log_configuration

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -281,6 +281,10 @@ variable log_configuration {
     logDriver = string
     options   = map(string)
   })
+  default     = {
+    logDriver = "awslogs"
+    options = {}
+  }
   description = <<EOF
   Log configuration options to send to a custom log driver for the container.
   For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LogConfiguration.html
@@ -290,7 +294,6 @@ variable log_configuration {
 
   Use log_secrets to set extra options here that should be secret, such as API keys for third party loggers.
   EOF
-  default     = null
 }
 
 variable log_secrets {


### PR DESCRIPTION
This can prevent a type mismatch error

```
Error: Inconsistent conditional result types

  on .terraform/modules/sombra.container_definition/main.tf line 95, in module "definition":
  95:   log_configuration = var.use_cloudwatch_logs ? {
  96:     logDriver = "awslogs"
  97:     options = {
  98:       "awslogs-region"        = var.aws_region
  99:       "awslogs-group"         = aws_cloudwatch_log_group.log_group[0].name
 100:       "awslogs-stream-prefix" = "ecs--${var.name}"
 101:     }
 102:     secretOptions = []
 103:     } : merge(var.log_configuration, {
 104:       secretOptions = concat(var.extra_log_secret_options, [
 105:         for name, outputs in aws_ssm_parameter.secret_log_options :
 106:         {
 107:           name      = name
 108:           valueFrom = outputs.arn
 109:         }
 110:       ])
 111:   })
    |----------------
    | aws_cloudwatch_log_group.log_group[0].name is "prod-one-lb-container-log-group"
    | aws_ssm_parameter.secret_log_options is object with no attributes
    | var.aws_region is "eu-west-1"
    | var.extra_log_secret_options is empty list of object
    | var.log_configuration is null
    | var.name is "prod-one-lb-container"
    | var.use_cloudwatch_logs is true
```