### PR TITLE
Remove deprecated cycle keys

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -67,10 +67,6 @@ module container_definition {
     # Override internal key
     INTERNAL_KEY_HASH = var.internal_key_hash
 
-    # Cycle
-    HMAC_NONCE_KEY_CYCLE      = var.hmac_nonce_key_cycle
-    KEY_ENCRYPTION_BASE_CYCLE = var.key_encryption_base_cycle
-
     NODE_ENV      = "production"
     TRANSCEND_URL = var.transcend_backend_url
     TRANSCEND_CN  = var.transcend_certificate_common_name

--- a/variables.tf
+++ b/variables.tf
@@ -157,16 +157,6 @@ variable internal_key_hash {
   description = "This will override the generated internal key"
 }
 
-variable hmac_nonce_key_cycle {
-  default     = ""
-  description = "Cycled HMAC nonce key (384 bits), held around during a key cycle process for requests made before the cycle"
-}
-
-variable key_encryption_base_cycle {
-  default     = ""
-  description = "Cycled High entropy secret value for local KMS (256 bits)"
-}
-
 variable transcend_backend_url {
   default     = "https://api.transcend.io:443"
   description = "URL of Transcend's backend"


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- Part of https://github.com/transcend-io/main/issues/6721

## Description

We don't use these vars any more to cycle keys. Removing them should have no impact.

## Security Implications

- _[none]_

## System Availability

- _[none]_