### PR TITLE
Require TLS v1.2 to communicate to sombras

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .terraform
+.terraform.lock.hcl

--- a/modules/sombra_load_balancers/separate_albs.tf
+++ b/modules/sombra_load_balancers/separate_albs.tf
@@ -26,7 +26,7 @@ module internal_load_balancer {
   https_listeners = [{
     certificate_arn = var.certificate_arn
     port            = var.internal_port
-    ssl_policy      = "ELBSecurityPolicy-2016-08"
+    ssl_policy      = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
   }]
 
   # Target groups
@@ -126,7 +126,7 @@ module external_load_balancer {
   https_listeners = [{
     certificate_arn = var.certificate_arn
     port            = var.external_port
-    ssl_policy      = "ELBSecurityPolicy-FS-2018-06"
+    ssl_policy      = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
   }]
 
   # Target groups

--- a/modules/sombra_load_balancers/single_alb.tf
+++ b/modules/sombra_load_balancers/single_alb.tf
@@ -36,7 +36,7 @@ module load_balancer {
     {
       certificate_arn    = var.certificate_arn
       port               = var.external_port
-      ssl_policy         = "ELBSecurityPolicy-FS-2018-06"
+      ssl_policy         = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
       target_group_index = 1
     },
   ]


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- https://github.com/transcend-io/main/issues/10176

## Description

Requires TLS v1.2 on all sombras

## Security Implications

- Requires TLS v1.2 on all sombras