### PR TITLE
Add support for load balancer idle_timeout setting

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,7 @@ module "load_balancer" {
   deploy_env        = var.deploy_env
   project_id        = var.project_id
   alb_access_logs   = var.alb_access_logs
+  idle_timeout      = var.idle_timeout
 
   # Ports and Firewall settings
   internal_port         = var.internal_port

--- a/modules/sombra_load_balancers/single_alb.tf
+++ b/modules/sombra_load_balancers/single_alb.tf
@@ -7,16 +7,17 @@ locals {
   alb_name             = local.should_override_name ? var.override_alb_name : "${var.project_id}-sombra-alb"
 }
 
-module load_balancer {
+module "load_balancer" {
   source  = "terraform-aws-modules/alb/aws"
   version = "5.10.0"
 
-  create_lb = ! var.use_private_load_balancer
+  create_lb = !var.use_private_load_balancer
 
   # General Settings
   name                       = local.alb_name
   enable_deletion_protection = false
   access_logs                = var.alb_access_logs
+  idle_timeout               = var.idle_timeout
 
   # VPC Settings
   subnets         = var.public_subnet_ids
@@ -80,7 +81,7 @@ module "single_security_group" {
   source  = "terraform-aws-modules/security-group/aws"
   version = "3.17.0"
 
-  create = ! var.use_private_load_balancer
+  create = !var.use_private_load_balancer
 
   name        = "${var.project_id}-sombra-alb"
   description = "Security group for sombra alb"

--- a/modules/sombra_load_balancers/variables.tf
+++ b/modules/sombra_load_balancers/variables.tf
@@ -102,6 +102,12 @@ variable override_alb_name {
   description = "If set as a string, this custom name will be used on the alb resources"
 }
 
+variable "idle_timeout" {
+  type = number
+  default = 60
+  description = "The time in seconds that the connection is allowed to be idle"
+}
+
 variable tags {
   type        = map(string)
   description = "Tags to apply to all resources that support them"

--- a/variables.tf
+++ b/variables.tf
@@ -359,6 +359,12 @@ variable "override_alb_name" {
   description = "If set as a string, this custom name will be used on the alb resources"
 }
 
+variable "idle_timeout" {
+  type = number
+  default = 60
+  description = "The time in seconds that the connection is allowed to be idle"
+}
+
 variable "extra_envs" {
   type        = map(string)
   description = <<EOF


### PR DESCRIPTION
# Pull Request

Allows changing the `idle_timeout` for the load balancer for the sombra service.

## Related Github Issues

- _[none]_

## Description

TODO

## Security Implications

- _[none]_

## System Availability

- _[none]_