### PR TITLE
Allow terminating SSL on internal sombra

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -137,8 +137,10 @@ locals {
 }
 
 module "service" {
-  source  = "transcend-io/fargate-service/aws"
-  version = "0.6.2"
+  # DO NOT SUBMIT
+  # source  = "transcend-io/fargate-service/aws"
+  # version = "0.6.2"
+  source = "github.com/transcend-io/fargate-service?ref=dmattia/ingress_cidr"
 
   name         = "${var.deploy_env}-${var.project_id}-sombra-service"
   cpu          = var.cpu
@@ -148,7 +150,8 @@ module "service" {
 
   vpc_id                 = var.vpc_id
   subnet_ids             = var.private_subnet_ids
-  alb_security_group_ids = module.load_balancer.security_group_ids
+  alb_security_group_ids = var.use_network_load_balancer ? null : module.load_balancer.security_group_ids
+  ingress_cidr_blocks    = var.use_network_load_balancer ? var.network_load_balancer_ingress_cidr_blocks : null
   container_definitions = format(
     "[%s]",
     join(",", distinct(concat(

--- a/main.tf
+++ b/main.tf
@@ -140,7 +140,7 @@ module "service" {
   # DO NOT SUBMIT
   # source  = "transcend-io/fargate-service/aws"
   # version = "0.6.2"
-  source = "github.com/transcend-io/fargate-service?ref=dmattia/ingress_cidr"
+  source = "git::https://github.com/transcend-io/terraform-aws-fargate-service?ref=dmattia/ingress_cidr"
 
   name         = "${var.deploy_env}-${var.project_id}-sombra-service"
   cpu          = var.cpu

--- a/main.tf
+++ b/main.tf
@@ -137,10 +137,8 @@ locals {
 }
 
 module "service" {
-  # DO NOT SUBMIT
-  # source  = "transcend-io/fargate-service/aws"
-  # version = "0.6.2"
-  source = "git::https://github.com/transcend-io/terraform-aws-fargate-service?ref=dmattia/ingress_cidr"
+  source  = "transcend-io/fargate-service/aws"
+  version = "0.7.0"
 
   name         = "${var.deploy_env}-${var.project_id}-sombra-service"
   cpu          = var.cpu

--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,7 @@ module "load_balancer" {
   zone_id                   = var.zone_id
   certificate_arn           = var.certificate_arn
   use_private_load_balancer = var.use_private_load_balancer
+  use_network_load_balancer = var.use_network_load_balancer
 
   tags = var.tags
 }

--- a/modules/sombra_load_balancers/outputs.tf
+++ b/modules/sombra_load_balancers/outputs.tf
@@ -19,12 +19,12 @@ output private_zone_id {
 }
 
 output internal_listener_arn {
-  value       = var.use_network_load_balancer ? var.load_balancer.http_tcp_listener_arns[0] : var.use_private_load_balancer ? module.internal_load_balancer.https_listener_arns[0] : module.load_balancer.https_listener_arns[0]
+  value       = var.use_network_load_balancer ? module.load_balancer.http_tcp_listener_arns[0] : var.use_private_load_balancer ? module.internal_load_balancer.https_listener_arns[0] : module.load_balancer.https_listener_arns[0]
   description = "ARN of the internal sombra load balancer listener"
 }
 
 output external_listener_arn {
-  value       = var.use_network_load_balancer ? var.load_balancer.http_tcp_listener_arns[0] : var.use_private_load_balancer ? module.external_load_balancer.https_listener_arns[0] : module.load_balancer.https_listener_arns[1]
+  value       = var.use_network_load_balancer ? module.load_balancer.http_tcp_listener_arns[0] : var.use_private_load_balancer ? module.external_load_balancer.https_listener_arns[0] : module.load_balancer.https_listener_arns[1]
   description = "ARN of the external sombra load balancer listener"
 }
 

--- a/modules/sombra_load_balancers/outputs.tf
+++ b/modules/sombra_load_balancers/outputs.tf
@@ -9,7 +9,7 @@ output external_target_group_arn {
 }
 
 output security_group_ids {
-  value       = var.use_private_load_balancer ? [module.internal_security_group.this_security_group_id, module.external_security_group.this_security_group_id] : [module.single_security_group.this_security_group_id]
+  value       = var.use_network_load_balancer ? [] : var.use_private_load_balancer ? [module.internal_security_group.this_security_group_id, module.external_security_group.this_security_group_id] : [module.single_security_group.this_security_group_id]
   description = "The ids of all security groups set on the ALB. We require that the tasks can only talk to the ALB"
 }
 

--- a/modules/sombra_load_balancers/outputs.tf
+++ b/modules/sombra_load_balancers/outputs.tf
@@ -19,12 +19,12 @@ output private_zone_id {
 }
 
 output internal_listener_arn {
-  value       = var.use_private_load_balancer ? module.internal_load_balancer.https_listener_arns[0] : module.load_balancer.https_listener_arns[0]
+  value       = var.use_network_load_balancer ? var.load_balancer.http_tcp_listener_arns[0] : var.use_private_load_balancer ? module.internal_load_balancer.https_listener_arns[0] : module.load_balancer.https_listener_arns[0]
   description = "ARN of the internal sombra load balancer listener"
 }
 
 output external_listener_arn {
-  value       = var.use_private_load_balancer ? module.external_load_balancer.https_listener_arns[0] : module.load_balancer.https_listener_arns[1]
+  value       = var.use_network_load_balancer ? var.load_balancer.http_tcp_listener_arns[0] : var.use_private_load_balancer ? module.external_load_balancer.https_listener_arns[0] : module.load_balancer.https_listener_arns[1]
   description = "ARN of the external sombra load balancer listener"
 }
 

--- a/modules/sombra_load_balancers/single_alb.tf
+++ b/modules/sombra_load_balancers/single_alb.tf
@@ -53,7 +53,7 @@ module "load_balancer" {
     port               = var.external_port
     protocol           = "TCP"
     target_group_index = 1
-  }] : null
+  }] : []
 
   # Target groups
   target_groups = [

--- a/modules/sombra_load_balancers/single_alb.tf
+++ b/modules/sombra_load_balancers/single_alb.tf
@@ -27,7 +27,7 @@ module "load_balancer" {
   load_balancer_type = var.use_network_load_balancer ? "network" : "application"
 
   # Listeners for ALB
-  https_listeners = var.use_network_load_balancer ? null : [
+  https_listeners = var.use_network_load_balancer ? [] : [
     # Internal Listener
     {
       certificate_arn    = var.certificate_arn

--- a/modules/sombra_load_balancers/single_alb.tf
+++ b/modules/sombra_load_balancers/single_alb.tf
@@ -24,8 +24,10 @@ module "load_balancer" {
   vpc_id          = var.vpc_id
   security_groups = [module.single_security_group.this_security_group_id]
 
-  # Listeners
-  https_listeners = [
+  load_balancer_type = var.use_network_load_balancer ? "network" : "application"
+
+  # Listeners for ALB
+  https_listeners = var.use_network_load_balancer ? [] : [
     # Internal Listener
     {
       certificate_arn    = var.certificate_arn
@@ -41,6 +43,17 @@ module "load_balancer" {
       target_group_index = 1
     },
   ]
+
+  # Listeners for NLB
+  http_tcp_listeners = var.use_network_load_balancer ? [{
+    port               = var.internal_port
+    protocol           = "TCP"
+    target_group_index = 0
+  },{
+    port               = var.external_port
+    protocol           = "TCP"
+    target_group_index = 1
+  }] : []
 
   # Target groups
   target_groups = [

--- a/modules/sombra_load_balancers/single_alb.tf
+++ b/modules/sombra_load_balancers/single_alb.tf
@@ -22,7 +22,7 @@ module "load_balancer" {
   # VPC Settings
   subnets         = var.public_subnet_ids
   vpc_id          = var.vpc_id
-  security_groups = [module.single_security_group.this_security_group_id]
+  security_groups = var.use_network_load_balancer ? [] : [module.single_security_group.this_security_group_id]
 
   load_balancer_type = var.use_network_load_balancer ? "network" : "application"
 
@@ -94,7 +94,7 @@ module "single_security_group" {
   source  = "terraform-aws-modules/security-group/aws"
   version = "3.17.0"
 
-  create = !var.use_private_load_balancer
+  create = !var.use_private_load_balancer && !var.use_network_load_balancer
 
   name        = "${var.project_id}-sombra-alb"
   description = "Security group for sombra alb"

--- a/modules/sombra_load_balancers/single_alb.tf
+++ b/modules/sombra_load_balancers/single_alb.tf
@@ -27,7 +27,7 @@ module "load_balancer" {
   load_balancer_type = var.use_network_load_balancer ? "network" : "application"
 
   # Listeners for ALB
-  https_listeners = var.use_network_load_balancer ? [] : [
+  https_listeners = var.use_network_load_balancer ? null : [
     # Internal Listener
     {
       certificate_arn    = var.certificate_arn
@@ -53,7 +53,7 @@ module "load_balancer" {
     port               = var.external_port
     protocol           = "TCP"
     target_group_index = 1
-  }] : []
+  }] : null
 
   # Target groups
   target_groups = [

--- a/modules/sombra_load_balancers/single_alb.tf
+++ b/modules/sombra_load_balancers/single_alb.tf
@@ -60,7 +60,7 @@ module "load_balancer" {
     # Internal group
     {
       name             = "${var.deploy_env}-${var.project_id}-internal"
-      backend_protocol = var.health_check_protocol
+      backend_protocol = var.use_network_load_balancer ? "TCP" : var.health_check_protocol
       target_type      = "ip"
       backend_port     = var.internal_port
       health_check = {
@@ -74,7 +74,7 @@ module "load_balancer" {
     # External group
     {
       name             = "${var.deploy_env}-${var.project_id}-external"
-      backend_protocol = var.health_check_protocol
+      backend_protocol = var.use_network_load_balancer ? "TCP" : var.health_check_protocol
       target_type      = "ip"
       backend_port     = var.external_port
       health_check = {

--- a/modules/sombra_load_balancers/variables.tf
+++ b/modules/sombra_load_balancers/variables.tf
@@ -9,6 +9,17 @@ variable use_private_load_balancer {
   EOF
 }
 
+variable use_network_load_balancer {
+  type        = bool
+  description = <<EOF
+  If true, the internal load balancer will use a Network Load Balancer instead of an Application Load Balancer.
+
+  Use this if you plan to terminate SSL on the sombra itself, and not on the load balancer. This should always be
+  used with `tls_config` on the root module.
+  EOF
+  default = false
+}
+
 variable deploy_env {
   description = "The environment to deploy to, usually dev, staging, or prod"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -408,6 +408,12 @@ variable use_network_load_balancer {
   default = false
 }
 
+variable network_load_balancer_ingress_cidr_blocks {
+  type        = list(string)
+  description = "CIDR blocks that can talk to sombra when using an NLB"
+  default = ["0.0.0.0/0"]
+}
+
 variable "tags" {
   type        = map(string)
   description = "Tags to apply to all resources that support them"

--- a/variables.tf
+++ b/variables.tf
@@ -397,6 +397,17 @@ variable "extra_secret_envs" {
   default     = {}
 }
 
+variable use_network_load_balancer {
+  type        = bool
+  description = <<EOF
+  If true, the internal load balancer will use a Network Load Balancer instead of an Application Load Balancer.
+
+  Use this if you plan to terminate SSL on the sombra itself, and not on the load balancer. This should always be
+  used with `tls_config`.
+  EOF
+  default = false
+}
+
 variable "tags" {
   type        = map(string)
   description = "Tags to apply to all resources that support them"


### PR DESCRIPTION
# Pull Request

## Security Implications

- SSL can now be terminated on the internal sombra itself. This allows those willing to set their own certificates to avoid having SSL terminate at the ALB.