### PR TITLE
When using mTLS, use a separate load balancer for the internal/external sombra

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -137,10 +137,8 @@ locals {
 }
 
 module "service" {
-  // DO NOT SUBMIT: Change back
-  # source  = "transcend-io/fargate-service/aws"
-  # version = "0.7.0"
-  source = "git::https://github.com/transcend-io/terraform-aws-fargate-service?ref=dmattia/sgs_and_cidrs_in_lb_defn"
+  source  = "transcend-io/fargate-service/aws"
+  version = "0.8.0"
 
   name         = "${var.deploy_env}-${var.project_id}-sombra-service"
   cpu          = var.cpu

--- a/main.tf
+++ b/main.tf
@@ -174,7 +174,7 @@ module "service" {
       container_name   = module.container_definition.container_name
       container_port   = var.internal_port
       security_groups  = var.use_network_load_balancer ? [] : null
-      cidr_blocks      = var.use_network_load_balancer ? [var.network_load_balancer_ingress_cidr_blocks] : null
+      cidr_blocks      = var.use_network_load_balancer ? var.network_load_balancer_ingress_cidr_blocks : null
     },
     # External target group manager
     {

--- a/main.tf
+++ b/main.tf
@@ -181,8 +181,6 @@ module "service" {
       target_group_arn = module.load_balancer.external_target_group_arn
       container_name   = module.container_definition.container_name
       container_port   = var.external_port
-      security_groups  = module.load_balancer.security_group_ids
-      cidr_blocks      = []
     }
   ]
 

--- a/main.tf
+++ b/main.tf
@@ -181,6 +181,8 @@ module "service" {
       target_group_arn = module.load_balancer.external_target_group_arn
       container_name   = module.container_definition.container_name
       container_port   = var.external_port
+      security_groups  = module.load_balancer.security_group_ids
+      cidr_blocks      = []
     }
   ]
 

--- a/main.tf
+++ b/main.tf
@@ -137,8 +137,10 @@ locals {
 }
 
 module "service" {
-  source  = "transcend-io/fargate-service/aws"
-  version = "0.7.0"
+  // DO NOT SUBMIT: Change back
+  # source  = "transcend-io/fargate-service/aws"
+  # version = "0.7.0"
+  source = "git::https://github.com/transcend-io/terraform-aws-fargate-service?ref=dmattia/sgs_and_cidrs_in_lb_defn"
 
   name         = "${var.deploy_env}-${var.project_id}-sombra-service"
   cpu          = var.cpu
@@ -148,8 +150,7 @@ module "service" {
 
   vpc_id                 = var.vpc_id
   subnet_ids             = var.private_subnet_ids
-  alb_security_group_ids = var.use_network_load_balancer ? null : module.load_balancer.security_group_ids
-  ingress_cidr_blocks    = var.use_network_load_balancer ? var.network_load_balancer_ingress_cidr_blocks : null
+  alb_security_group_ids = module.load_balancer.security_group_ids
   container_definitions = format(
     "[%s]",
     join(",", distinct(concat(
@@ -172,12 +173,16 @@ module "service" {
       target_group_arn = module.load_balancer.internal_target_group_arn
       container_name   = module.container_definition.container_name
       container_port   = var.internal_port
+      security_groups  = var.use_network_load_balancer ? [] : null
+      cidr_blocks      = var.use_network_load_balancer ? [var.network_load_balancer_ingress_cidr_blocks] : null
     },
     # External target group manager
     {
       target_group_arn = module.load_balancer.external_target_group_arn
       container_name   = module.container_definition.container_name
       container_port   = var.external_port
+      security_groups  = module.load_balancer.security_group_ids
+      cidr_blocks      = []
     }
   ]
 

--- a/modules/sombra_load_balancers/outputs.tf
+++ b/modules/sombra_load_balancers/outputs.tf
@@ -9,7 +9,7 @@ output external_target_group_arn {
 }
 
 output security_group_ids {
-  value       = var.use_network_load_balancer ? [] : var.use_private_load_balancer ? [module.internal_security_group.this_security_group_id, module.external_security_group.this_security_group_id] : [module.single_security_group.this_security_group_id]
+  value       = var.use_network_load_balancer ? [module.external_security_group.this_security_group_id] : var.use_private_load_balancer ? [module.internal_security_group.this_security_group_id, module.external_security_group.this_security_group_id] : [module.single_security_group.this_security_group_id]
   description = "The ids of all security groups set on the ALB. We require that the tasks can only talk to the ALB"
 }
 
@@ -19,12 +19,12 @@ output private_zone_id {
 }
 
 output internal_listener_arn {
-  value       = var.use_network_load_balancer ? module.load_balancer.http_tcp_listener_arns[0] : var.use_private_load_balancer ? module.internal_load_balancer.https_listener_arns[0] : module.load_balancer.https_listener_arns[0]
+  value       = var.use_network_load_balancer ? module.internal_load_balancer.http_tcp_listener_arns[0] : var.use_private_load_balancer ? module.internal_load_balancer.https_listener_arns[0] : module.load_balancer.https_listener_arns[0]
   description = "ARN of the internal sombra load balancer listener"
 }
 
 output external_listener_arn {
-  value       = var.use_network_load_balancer ? module.load_balancer.http_tcp_listener_arns[0] : var.use_private_load_balancer ? module.external_load_balancer.https_listener_arns[0] : module.load_balancer.https_listener_arns[1]
+  value       = var.use_private_load_balancer ? module.external_load_balancer.https_listener_arns[0] : module.load_balancer.https_listener_arns[1]
   description = "ARN of the external sombra load balancer listener"
 }
 

--- a/modules/sombra_load_balancers/outputs.tf
+++ b/modules/sombra_load_balancers/outputs.tf
@@ -1,10 +1,10 @@
 output internal_target_group_arn {
-  value       = var.use_private_load_balancer ? module.internal_load_balancer.target_group_arns[0] : module.load_balancer.target_group_arns[0]
+  value       = var.use_private_load_balancer || var.use_network_load_balancer ? module.internal_load_balancer.target_group_arns[0] : module.load_balancer.target_group_arns[0]
   description = "ARN of the internal sombra load balancer target group"
 }
 
 output external_target_group_arn {
-  value       = var.use_private_load_balancer ? module.external_load_balancer.target_group_arns[0] : module.load_balancer.target_group_arns[1]
+  value       = var.use_private_load_balancer || var.use_network_load_balancer ? module.external_load_balancer.target_group_arns[0] : module.load_balancer.target_group_arns[1]
   description = "ARN of the external sombra load balancer target group"
 }
 
@@ -24,11 +24,11 @@ output internal_listener_arn {
 }
 
 output external_listener_arn {
-  value       = var.use_private_load_balancer ? module.external_load_balancer.https_listener_arns[0] : module.load_balancer.https_listener_arns[1]
+  value       = var.use_private_load_balancer || var.use_network_load_balancer ? module.external_load_balancer.https_listener_arns[0] : module.load_balancer.https_listener_arns[1]
   description = "ARN of the external sombra load balancer listener"
 }
 
 output arn_suffix {
-  value       = var.use_private_load_balancer ? "" : module.load_balancer.this_lb_arn_suffix
+  value       = var.use_private_load_balancer || var.use_network_load_balancer ? "" : module.load_balancer.this_lb_arn_suffix
   description = "Amazon Resource Name suffix for the load balancer. Only present in single alb configurations"
 }

--- a/modules/sombra_load_balancers/separate_albs.tf
+++ b/modules/sombra_load_balancers/separate_albs.tf
@@ -194,7 +194,7 @@ resource "aws_route53_record" "external_alb_alias" {
   count = var.use_private_load_balancer || var.use_network_load_balancer ? 1 : 0
 
   zone_id = var.zone_id
-  name    = var.use_private_load_balancer ? "${var.subdomain}.${var.root_domain}" : "external.${var.subdomain}.${var.root_domain}"
+  name    = var.use_private_load_balancer ? "${var.subdomain}.${var.root_domain}" : "external-${var.subdomain}.${var.root_domain}"
   type    = "A"
 
   alias {

--- a/modules/sombra_load_balancers/separate_albs.tf
+++ b/modules/sombra_load_balancers/separate_albs.tf
@@ -6,33 +6,43 @@ module internal_load_balancer {
   source  = "terraform-aws-modules/alb/aws"
   version = "5.10.0"
 
-  create_lb = var.use_private_load_balancer
+  create_lb = var.use_private_load_balancer || var.use_network_load_balancer
 
   # General Settings
   name                       = "${var.project_id}-sombra-internal"
   enable_deletion_protection = false
   access_logs                = var.alb_access_logs
+  idle_timeout               = var.idle_timeout
 
   # VPC Settings
   subnets         = var.private_subnet_ids
   vpc_id          = var.vpc_id
-  security_groups = [module.internal_security_group.this_security_group_id]
+  security_groups = var.use_network_load_balancer ? [] : [module.internal_security_group.this_security_group_id]
 
-  # Make this only internal to the VPC
-  internal        = true
+  # Make this only internal to the VPC, if specified
+  internal        = var.use_private_load_balancer
   ip_address_type = "ipv4"
 
-  # Listeners
-  https_listeners = [{
+  load_balancer_type = var.use_network_load_balancer ? "network" : "application"
+
+  # Listeners if ALB
+  https_listeners = var.use_network_load_balancer ? [] : [{
     certificate_arn = var.certificate_arn
     port            = var.internal_port
     ssl_policy      = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
   }]
 
+  # Listeners if NLB
+  http_tcp_listeners = var.use_network_load_balancer ? [{
+    port               = var.internal_port
+    protocol           = "TCP"
+    target_group_index = 0
+  }] : []
+
   # Target groups
   target_groups = [{
     name             = "${var.deploy_env}-${var.project_id}-internal"
-    backend_protocol = var.health_check_protocol
+    backend_protocol = var.use_network_load_balancer ? "TCP" : var.health_check_protocol
     target_type      = "ip"
     backend_port     = var.internal_port
     health_check = {
@@ -51,7 +61,7 @@ module "internal_security_group" {
   source  = "terraform-aws-modules/security-group/aws"
   version = "3.17.0"
 
-  create = var.use_private_load_balancer
+  create = var.use_private_load_balancer && !var.use_network_load_balancer
 
   name        = "${var.project_id}-internal-alb"
   description = "Security group for the internal, private sombra alb"
@@ -89,9 +99,9 @@ resource "aws_route53_zone" "private" {
 }
 
 resource "aws_route53_record" "alb_alias" {
-  count = var.use_private_load_balancer ? 1 : 0
+  count = var.use_private_load_balancer || var.use_network_load_balancer ? 1 : 0
 
-  zone_id = aws_route53_zone.private[0].zone_id
+  zone_id = var.use_private_load_balancer ? aws_route53_zone.private[0].zone_id : var.zone_id
   name    = "${var.subdomain}.${var.root_domain}"
   type    = "A"
 
@@ -110,7 +120,7 @@ module external_load_balancer {
   source  = "terraform-aws-modules/alb/aws"
   version = "5.10.0"
 
-  create_lb = var.use_private_load_balancer
+  create_lb = var.use_private_load_balancer || var.use_network_load_balancer
 
   # General Settings
   name                       = "${var.project_id}-sombra-external"

--- a/modules/sombra_load_balancers/separate_albs.tf
+++ b/modules/sombra_load_balancers/separate_albs.tf
@@ -161,7 +161,7 @@ module "external_security_group" {
   source  = "terraform-aws-modules/security-group/aws"
   version = "3.17.0"
 
-  create = var.use_private_load_balancer
+  create = var.use_private_load_balancer || var.use_network_load_balancer
 
   name        = "${var.project_id}-external-alb"
   description = "Security group for the external, public sombra alb"
@@ -191,7 +191,7 @@ module "external_security_group" {
 ###########################################################
 
 resource "aws_route53_record" "external_alb_alias" {
-  count = var.use_private_load_balancer ? 1 : 0
+  count = var.use_private_load_balancer || var.use_network_load_balancer ? 1 : 0
 
   zone_id = var.zone_id
   name    = "${var.subdomain}.${var.root_domain}"

--- a/modules/sombra_load_balancers/separate_albs.tf
+++ b/modules/sombra_load_balancers/separate_albs.tf
@@ -194,7 +194,7 @@ resource "aws_route53_record" "external_alb_alias" {
   count = var.use_private_load_balancer || var.use_network_load_balancer ? 1 : 0
 
   zone_id = var.zone_id
-  name    = "${var.subdomain}.${var.root_domain}"
+  name    = var.use_private_load_balancer ? "${var.subdomain}.${var.root_domain}" : "external.${var.subdomain}.${var.root_domain}"
   type    = "A"
 
   alias {

--- a/modules/sombra_load_balancers/separate_albs.tf
+++ b/modules/sombra_load_balancers/separate_albs.tf
@@ -15,7 +15,7 @@ module internal_load_balancer {
   idle_timeout               = var.idle_timeout
 
   # VPC Settings
-  subnets         = var.private_subnet_ids
+  subnets         = var.use_private_load_balancer ? var.private_subnet_ids : var.public_subnet_ids
   vpc_id          = var.vpc_id
   security_groups = var.use_network_load_balancer ? [] : [module.internal_security_group.this_security_group_id]
 

--- a/modules/sombra_load_balancers/separate_albs.tf
+++ b/modules/sombra_load_balancers/separate_albs.tf
@@ -150,7 +150,7 @@ module external_load_balancer {
       interval = 30
       port     = var.external_port
       path     = "/health"
-      backend_protocol = var.health_check_protocol
+      protocol = var.health_check_protocol
     }
   }]
 


### PR DESCRIPTION
an NLB means the cert on sombra must be verified by the client using our custom CA cert. This is good for mTLS on the customer-facing, internal sombra, but is not necessary for our external sombra that our backend talks to. This enables us to communicate to sombra over standard HTTPS using an SSL cert from the Amazon CA without needing to make backend changes