### PR TITLE
Pin vault provider to version that doesn't greedily check token validation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,7 @@
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
 	"features": {
-		"terraform": "1.2",
+		"terraform": "1.6",
 		"aws-cli": "latest"
 	}
 }

--- a/examples/http/main.tf
+++ b/examples/http/main.tf
@@ -13,6 +13,7 @@ provider "vault" {
   token   = "not-a-real-token"
   skip_tls_verify = true
   skip_child_token = true
+  skip_get_vault_version = true
 }
 
 locals {
@@ -25,7 +26,7 @@ locals {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 2.18.0"
+  version = "~> 5.1.2"
 
   name = "sombra-example-http-test-vpc"
   cidr = "10.0.0.0/16"
@@ -52,7 +53,7 @@ module "acm" {
 
 module "sombra" {
   source  = "transcend-io/sombra/aws"
-  version = "1.4.1"
+  version = "1.5.0"
 
   # General Settings
   deploy_env       = "example"

--- a/examples/https/main.tf
+++ b/examples/https/main.tf
@@ -13,6 +13,7 @@ provider "vault" {
   token   = "not-a-real-token"
   skip_tls_verify = true
   skip_child_token = true
+  skip_get_vault_version = true
 }
 
 locals {
@@ -25,7 +26,7 @@ locals {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 2.18.0"
+  version = "~> 5.1.2"
 
   name = "sombra-example-https-test-vpc"
   cidr = "10.0.0.0/16"
@@ -52,7 +53,7 @@ module "acm" {
 
 module "sombra" {
   source  = "transcend-io/sombra/aws"
-  version = "1.4.1"
+  version = "1.5.0"
 
   # General Settings
   deploy_env       = "example"

--- a/main.tf
+++ b/main.tf
@@ -138,8 +138,8 @@ locals {
 
 module "service" {
   source  = "transcend-io/fargate-service/aws"
-  version = "0.8.0"
-
+  version = "0.9.0"
+  
   name         = "${var.deploy_env}-${var.project_id}-sombra-service"
   cpu          = var.cpu
   memory       = var.memory

--- a/versions.tf
+++ b/versions.tf
@@ -3,6 +3,12 @@ terraform {
     aws = {
       source = "hashicorp/aws"
     }
+    # We cannot use versions 3.16.0 or higher due to this regression:
+    # https://github.com/hashicorp/terraform-provider-vault/issues/1907
+    vault = {
+      source = "hashicorp/vault"
+      version = "< 3.16.0"
+    }
   }
   required_version = ">= 0.13"
 }


### PR DESCRIPTION
See: https://github.com/hashicorp/terraform-provider-vault/issues/1907

This is necessary for this module to work for customers that do not use Vault