### PR TITLE
Support the LLM Classifier on ECS

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ After that, you can reference the `internal_url` output from your backend over H
   <i>Copyright © 2020 Transcend Inc.</i>
 </p>
 
+## LLM Classifier
+
+Deploying the LLM Classifier is optional, and can be done with the following steps:
+
+- Set the `deploy_llm` variable to `true`
+- Customize the `llm_classifier_ecr_image` variable if you are using docker.transcend.io or want to customize the version tag
+- Customize the EC2 instance type used if you'd like via the `llm_classifier_instance_type` variable.
+
+Please note that there are considerable cost implications, as the LLM Classifier is a GPU-based system.
+
 ## Examples
 
 We have two examples of deploying soombra in the `./examples` folder, one for using `HTTP` and one for `HTTPS`.

--- a/main.tf
+++ b/main.tf
@@ -140,7 +140,7 @@ locals {
 
 module "service" {
   source  = "transcend-io/fargate-service/aws"
-  version = "0.9.3"
+  version = "0.9.1"
 
   name         = "${var.deploy_env}-${var.project_id}-sombra-service"
   cpu          = var.cpu

--- a/main.tf
+++ b/main.tf
@@ -265,7 +265,7 @@ resource "aws_launch_configuration" "llm_classifier_lc" {
 
   user_data = <<-EOF
     #!/bin/bash
-    echo "ECS_CLUSTER=MyCluster" >> /etc/ecs/ecs.config
+    echo "ECS_CLUSTER=${local.cluster_name}" >> /etc/ecs/ecs.config
   EOF
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -147,13 +147,15 @@ locals {
 
 module "service" {
   source  = "transcend-io/fargate-service/aws"
-  version = "0.9.3"
+  version = "0.9.4"
 
   name         = "${var.deploy_env}-${var.project_id}-sombra-service"
   cpu          = var.cpu
   memory       = var.memory
   cluster_id   = local.cluster_id
   cluster_name = local.cluster_name
+
+  service_connect_namespace = local.cluster_namespace
 
   vpc_id                 = var.vpc_id
   subnet_ids             = var.private_subnet_ids

--- a/main.tf
+++ b/main.tf
@@ -351,7 +351,7 @@ resource "aws_iam_role_policy_attachment" "ssm_instance_role_policy" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
-resource "aws_iam_role_policy_attachment" "ssm_instance_role_policy" {
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {
   role       = aws_iam_role.ecs_instance_role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonECSTaskExecutionRolePolicy"
 }

--- a/main.tf
+++ b/main.tf
@@ -210,7 +210,7 @@ resource "aws_ecs_cluster" "cluster" {
   tags  = var.tags
 }
 
-resource "aws_ecs_cluster_capacity_providers" "example" {
+resource "aws_ecs_cluster_capacity_providers" "capacity_with_fargate_and_gpu" {
   count = var.cluster_id == "" && var.deploy_llm ? 1 : 0
   cluster_name = aws_ecs_cluster.cluster[0].name
 
@@ -243,6 +243,11 @@ resource "aws_autoscaling_group" "llm_classifier_asg" {
   tag {
     key                 = "Name"
     value               = "${var.deploy_env}-${var.project_id}-llm-classifier-asg"
+    propagate_at_launch = true
+  }
+  tag {
+    key                 = "AmazonECSManaged"
+    value               = true
     propagate_at_launch = true
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -274,7 +274,7 @@ resource "aws_launch_configuration" "llm_classifier_lc" {
   }
 }
 
-resource "aws_security_group" "llm_classifier_instances-sg" {
+resource "aws_security_group" "llm_classifier_instances_sg" {
   name        = "${var.deploy_env}-${var.project_id}-llm-classifier-instances-sg"
   description = "Security group for LLM Classifier ECS instances"
   vpc_id      = var.vpc_id

--- a/main.tf
+++ b/main.tf
@@ -351,6 +351,11 @@ resource "aws_iam_role_policy_attachment" "ssm_instance_role_policy" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
+resource "aws_iam_role_policy_attachment" "ssm_instance_role_policy" {
+  role       = aws_iam_role.ecs_instance_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonECSTaskExecutionRolePolicy"
+}
+
 resource "aws_iam_instance_profile" "ecs_instance_profile" {
   name = "${var.deploy_env}-${var.project_id}-ecs-instance-profile"
   role = aws_iam_role.ecs_instance_role.name

--- a/main.tf
+++ b/main.tf
@@ -258,7 +258,7 @@ data "aws_ami" "amazon_linux_2" {
 
   filter {
     name   = "name"
-    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+    values = ["/aws/service/ecs/optimized-ami/amazon-linux-2/gpu/recommended"]
   }
 
   filter {

--- a/main.tf
+++ b/main.tf
@@ -445,6 +445,12 @@ resource "aws_iam_policy" "aws_policy" {
 # LLM Classifier #
 ##################
 
+resource "aws_cloudwatch_log_group" "llm_logs" {
+  count = var.use_cloudwatch_logs ? 1 : 0
+  name  = "${var.deploy_env}-${var.project_id}-llm-classifier-log-group"
+  tags  = var.tags
+}
+
 resource "aws_ecs_task_definition" "llm_classifier_task" {
   count                    = var.deploy_llm ? 1 : 0
   family                   = "${var.deploy_env}-${var.project_id}-llm-classifier"
@@ -484,7 +490,7 @@ resource "aws_ecs_task_definition" "llm_classifier_task" {
       logConfiguration = {
         logDriver = "awslogs"
         options = {
-          awslogs-group         = "/ecs/${var.deploy_env}-${var.project_id}-llm-classifier"
+          awslogs-group         = aws_cloudwatch_log_group.llm_logs[0].name
           awslogs-region        = var.aws_region
           awslogs-stream-prefix = "ecs"
         }

--- a/main.tf
+++ b/main.tf
@@ -262,10 +262,14 @@ data "aws_ami" "amazon_linux_2" {
   }
 }
 
+data "aws_ssm_parameter" "ecs_optimized_ami" {
+  name = "/aws/service/ecs/optimized-ami/amazon-linux-2/gpu/recommended"
+}
+
 resource "aws_launch_configuration" "llm_classifier_lc" {
   count = var.cluster_id == "" && var.deploy_llm ? 1 : 0
   name          = "${var.deploy_env}-${var.project_id}-llm-classifier-launch"
-  image_id      = data.aws_ami.amazon_linux_2.id
+  image_id      = jsondecode(data.aws_ssm_parameter.ecs_optimized_ami.value).image_id
   instance_type = var.llm_classifier_instance_type
   iam_instance_profile = aws_iam_instance_profile.ecs_instance_profile.name
 

--- a/main.tf
+++ b/main.tf
@@ -260,11 +260,6 @@ data "aws_ami" "amazon_linux_2" {
     name   = "name"
     values = ["/aws/service/ecs/optimized-ami/amazon-linux-2/gpu/recommended"]
   }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
 }
 
 resource "aws_launch_configuration" "llm_classifier_lc" {

--- a/main.tf
+++ b/main.tf
@@ -140,7 +140,7 @@ locals {
 
 module "service" {
   source  = "transcend-io/fargate-service/aws"
-  version = "0.9.1"
+  version = "0.9.3"
 
   name         = "${var.deploy_env}-${var.project_id}-sombra-service"
   cpu          = var.cpu

--- a/main.tf
+++ b/main.tf
@@ -295,6 +295,11 @@ resource "aws_iam_role_policy_attachment" "ecs_instance_role_policy" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
 }
 
+resource "aws_iam_role_policy_attachment" "ssm_instance_role_policy" {
+  role       = aws_iam_role.ecs_instance_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
 resource "aws_iam_instance_profile" "ecs_instance_profile" {
   name = "${var.deploy_env}-${var.project_id}-ecs-instance-profile"
   role = aws_iam_role.ecs_instance_role.name

--- a/main.tf
+++ b/main.tf
@@ -469,7 +469,7 @@ resource "aws_ecs_task_definition" "llm_classifier_task" {
         }
       ]
       environment = [
-        { name = "LLM_SERVER_PORT", value = "${var.llm_classifier_port}" },
+        { name = "LLM_SERVER_PORT", value = tostring(var.llm_classifier_port) },
         { name = "LLM_SERVER_CONCURRENCY", value = "2" },
         { name = "LLM_SERVER_TIMEOUT", value = "120" }
       ]

--- a/main.tf
+++ b/main.tf
@@ -73,6 +73,8 @@ module "container_definition" {
     INTERNAL_PORT_HTTP  = var.internal_port
     USE_TLS_AUTH        = false
 
+    LLM_CLASSIFIER_URL = var.deploy_llm ? "http://llm-classifier:${var.llm_classifier_port}" : null
+
     # JWT
     JWT_AUTHENTICATION_PUBLIC_KEY = var.jwt_authentication_public_key
 

--- a/main.tf
+++ b/main.tf
@@ -269,7 +269,7 @@ data "aws_ami" "amazon_linux_2" {
 
 resource "aws_launch_configuration" "llm_classifier_lc" {
   count = var.cluster_id == "" && var.deploy_llm ? 1 : 0
-  name          = "${var.deploy_env}-${var.project_id}-llm-classifier-lc"
+  name          = "${var.deploy_env}-${var.project_id}-llm-classifier-launch"
   image_id      = data.aws_ami.amazon_linux_2.id
   instance_type = var.llm_classifier_instance_type
   iam_instance_profile = aws_iam_instance_profile.ecs_instance_profile.name

--- a/main.tf
+++ b/main.tf
@@ -252,16 +252,6 @@ resource "aws_autoscaling_group" "llm_classifier_asg" {
   }
 }
 
-data "aws_ami" "amazon_linux_2" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name   = "name"
-    values = ["/aws/service/ecs/optimized-ami/amazon-linux-2/gpu/recommended"]
-  }
-}
-
 data "aws_ssm_parameter" "ecs_optimized_ami" {
   name = "/aws/service/ecs/optimized-ami/amazon-linux-2/gpu/recommended"
 }

--- a/main.tf
+++ b/main.tf
@@ -462,6 +462,14 @@ resource "aws_ecs_task_definition" "llm_classifier_task" {
       essential = true
       memory    = 8192
       cpu       = 2048
+      "portMappings": [
+        {
+          containerPort = var.llm_classifier_port
+          hostPort = var.llm_classifier_port
+          name = "llm-classifier"
+          protocol = "tcp"
+        }
+      ],
       resourceRequirements = [
         {
           type  = "GPU"

--- a/main.tf
+++ b/main.tf
@@ -264,6 +264,10 @@ resource "aws_launch_configuration" "llm_classifier_lc" {
   iam_instance_profile = aws_iam_instance_profile.ecs_instance_profile.name
   security_groups = [aws_security_group.llm_classifier_instances_sg.id]
 
+  root_block_device {
+    volume_size = 100
+  }
+
   user_data = <<-EOF
     #!/bin/bash
     echo "ECS_CLUSTER=${local.cluster_name}" >> /etc/ecs/ecs.config

--- a/main.tf
+++ b/main.tf
@@ -220,7 +220,7 @@ resource "aws_ecs_cluster" "cluster" {
   name  = "${var.deploy_env}-${var.project_id}-sombra-cluster"
 
   service_connect_defaults {
-    namespace = aws_service_discovery_http_namespace.sombra_namespace[0].id
+    namespace = aws_service_discovery_http_namespace.sombra_namespace[0].arn
   }
 
   tags  = var.tags
@@ -384,7 +384,7 @@ resource "aws_iam_instance_profile" "ecs_instance_profile" {
 locals {
   cluster_id   = var.cluster_id == "" ? aws_ecs_cluster.cluster[0].id : var.cluster_id
   cluster_name = var.cluster_name == "" ? aws_ecs_cluster.cluster[0].name : var.cluster_name
-  cluster_namespace = var.cluster_namespace == "" ? aws_service_discovery_http_namespace.sombra_namespace[0].id : var.cluster_namespace
+  cluster_namespace = var.cluster_namespace == "" ? aws_service_discovery_http_namespace.sombra_namespace[0].name : var.cluster_namespace
 }
 
 ##############

--- a/main.tf
+++ b/main.tf
@@ -258,10 +258,15 @@ data "aws_ssm_parameter" "ecs_optimized_ami" {
 
 resource "aws_launch_configuration" "llm_classifier_lc" {
   count = var.cluster_id == "" && var.deploy_llm ? 1 : 0
-  name          = "${var.deploy_env}-${var.project_id}-llm-classifier-launch"
+  name_prefix          = "${var.deploy_env}-${var.project_id}-llm-classifier"
   image_id      = jsondecode(data.aws_ssm_parameter.ecs_optimized_ami.value).image_id
   instance_type = var.llm_classifier_instance_type
   iam_instance_profile = aws_iam_instance_profile.ecs_instance_profile.name
+
+  user_data = <<-EOF
+    #!/bin/bash
+    echo "ECS_CLUSTER=MyCluster" >> /etc/ecs/ecs.config
+  EOF
 
   lifecycle {
     create_before_destroy = true

--- a/main.tf
+++ b/main.tf
@@ -282,9 +282,37 @@ resource "aws_iam_role" "ecs_instance_role" {
       {
         Effect = "Allow"
         Principal = {
-          Service = "ec2.amazonaws.com"
+          Service = [
+            "ec2.amazonaws.com",
+            "ecs.amazonaws.com",
+            "ecs-tasks.amazonaws.com"
+          ]
         }
         Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "ecs_instance_role_policy" {
+  name   = "${var.deploy_env}-${var.project_id}-ecs-instance-role-policy"
+  role   = aws_iam_role.ecs_instance_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:PutLogEvents",
+          "logs:CreateLogStream",
+          "logs:CreateLogGroup",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:GetAuthorizationToken",
+          "ecr:BatchGetImage",
+          "ecr:BatchCheckLayerAvailability"
+        ]
+        Resource = "*"
       }
     ]
   })

--- a/main.tf
+++ b/main.tf
@@ -140,7 +140,7 @@ locals {
 
 module "service" {
   source  = "transcend-io/fargate-service/aws"
-  version = "0.9.1"
+  version = "0.9.2"
 
   name         = "${var.deploy_env}-${var.project_id}-sombra-service"
   cpu          = var.cpu

--- a/main.tf
+++ b/main.tf
@@ -140,7 +140,7 @@ locals {
 
 module "service" {
   source  = "transcend-io/fargate-service/aws"
-  version = "0.9.2"
+  version = "0.9.3"
 
   name         = "${var.deploy_env}-${var.project_id}-sombra-service"
   cpu          = var.cpu

--- a/main.tf
+++ b/main.tf
@@ -272,10 +272,38 @@ resource "aws_launch_configuration" "llm_classifier_lc" {
   name          = "${var.deploy_env}-${var.project_id}-llm-classifier-lc"
   image_id      = data.aws_ami.amazon_linux_2.id
   instance_type = var.llm_classifier_instance_type
+  iam_instance_profile = aws_iam_instance_profile.ecs_instance_profile.name
 
   lifecycle {
     create_before_destroy = true
   }
+}
+
+resource "aws_iam_role" "ecs_instance_role" {
+  name = "${var.deploy_env}-${var.project_id}-ecs-instance-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_instance_role_policy" {
+  role       = aws_iam_role.ecs_instance_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+resource "aws_iam_instance_profile" "ecs_instance_profile" {
+  name = "${var.deploy_env}-${var.project_id}-ecs-instance-profile"
+  role = aws_iam_role.ecs_instance_role.name
 }
 
 locals {

--- a/main.tf
+++ b/main.tf
@@ -229,7 +229,7 @@ resource "aws_ecs_capacity_provider" "llm_classifier_capacity_provider" {
 
   auto_scaling_group_provider {
     auto_scaling_group_arn         = aws_autoscaling_group.llm_classifier_asg[0].arn
-    managed_termination_protection = "ENABLED"
+    managed_termination_protection = "DISABLED"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -262,6 +262,7 @@ resource "aws_launch_configuration" "llm_classifier_lc" {
   image_id      = jsondecode(data.aws_ssm_parameter.ecs_optimized_ami.value).image_id
   instance_type = var.llm_classifier_instance_type
   iam_instance_profile = aws_iam_instance_profile.ecs_instance_profile.name
+  security_groups = [aws_security_group.llm_classifier_instances_sg.id]
 
   user_data = <<-EOF
     #!/bin/bash
@@ -271,6 +272,28 @@ resource "aws_launch_configuration" "llm_classifier_lc" {
   lifecycle {
     create_before_destroy = true
   }
+}
+
+resource "aws_security_group" "llm_classifier_instances-sg" {
+  name        = "${var.deploy_env}-${var.project_id}-llm-classifier-instances-sg"
+  description = "Security group for LLM Classifier ECS instances"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = var.private_subnets_cidr_blocks
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = var.tags
 }
 
 resource "aws_iam_role" "ecs_instance_role" {

--- a/main.tf
+++ b/main.tf
@@ -86,6 +86,7 @@ module "container_definition" {
 
     # Global Settings
     ORGANIZATION_URI                    = var.organization_uri
+    SOMBRA_ID                           = var.sombra_id
     DATA_SUBJECT_AUTHENTICATION_METHODS = join(",", var.data_subject_auth_methods)
     EMPLOYEE_AUTHENTICATION_METHODS     = join(",", var.employee_auth_methods)
 

--- a/main.tf
+++ b/main.tf
@@ -353,7 +353,7 @@ resource "aws_iam_role_policy_attachment" "ssm_instance_role_policy" {
 
 resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {
   role       = aws_iam_role.ecs_instance_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonECSTaskExecutionRolePolicy"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
 resource "aws_iam_instance_profile" "ecs_instance_profile" {

--- a/main.tf
+++ b/main.tf
@@ -52,10 +52,10 @@ module "container_definition" {
   containerPorts = [var.internal_port, var.external_port]
   ssm_prefix     = var.project_id
 
-  portNames = {
-    "${var.internal_port}" = "internalSombra"
-    "${var.external_port}" = "externalSombra"
-  }
+  portNames = tomap({
+    tostring(var.internal_port) = "internalSombra",
+    tostring(var.external_port) = "externalSombra"
+  })
 
   use_cloudwatch_logs = var.use_cloudwatch_logs
   log_configuration   = var.log_configuration

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,10 @@ variable "organization_uri" {
   description = "The unique URI for you organization from Transcend."
 }
 
+variable "sombra_id" {
+  description = "The unique ID of the sombra"
+}
+
 variable "vpc_id" {
   description = "The ID of the VPC to put this application into"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -35,7 +35,7 @@ variable "llm_classifier_ecr_image" {
 
 variable "llm_classifier_instance_type" {
   description = "The instance type to use for the LLM Classifier, which requires a GPU"
-  default     = "g5.xlarge"
+  default     = "g5.2xlarge"
 }
 
 variable "public_subnet_ids" {

--- a/variables.tf
+++ b/variables.tf
@@ -19,8 +19,23 @@ variable "vpc_id" {
 }
 
 variable "ecr_image" {
-  description = "Url of the ECR repo, including the tag"
+  description = "Url of the ECR repo, including the tag, for the Sombra image"
   default     = "829095311197.dkr.ecr.eu-west-1.amazonaws.com/sombra:prod"
+}
+
+variable "deploy_llm" {
+  description = "If true, the LLM Classifier will be deployed. Note that this has considerable cost implications"
+  default     = false
+}
+
+variable "llm_classifier_ecr_image" {
+  description = "Url of the ECR repo, including the tag, for the LLM Classifier"
+  default     = "829095311197.dkr.ecr.eu-west-1.amazonaws.com/llm-classifier:prod"
+}
+
+variable "llm_classifier_instance_type" {
+  description = "The instance type to use for the LLM Classifier, which requires a GPU"
+  default     = "g5.xlarge"
 }
 
 variable "public_subnet_ids" {

--- a/variables.tf
+++ b/variables.tf
@@ -136,6 +136,12 @@ variable "cluster_name" {
   default     = ""
 }
 
+variable "cluster_namespace" {
+  type        = string
+  description = "The service discovery namespace of the ECS cluster"
+  default     = ""
+}
+
 variable "alb_access_logs" {
   description = "Map containing access logging configuration for the load balancer."
   type        = map(string)
@@ -274,6 +280,11 @@ variable "internal_port" {
 variable "external_port" {
   description = "The port the external sombra should run on, this is the server that only Transcend's API talks to."
   default     = 5041
+}
+
+variable "llm_classifier_port" {
+  description = "The port the LLM Classifier should run on, if enabled"
+  default     = 6081
 }
 
 variable "log_level" {


### PR DESCRIPTION
# Pull Request

## Description

Allows optionally connecting the LLM classifier to Sombra via variables. This has noticeable cost implications for customers.

## Security Implications

The LLM Classifier lives in an ECS task running on an EC2 instance in the same cluster as the main Sombra image. They communicate inside the private subnets
