### PR TITLE
🤖🚩 Add opt-in sombra_container_version_consistency passthrough

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,8 +44,13 @@ module "load_balancer" {
 ############
 
 module "container_definition" {
-  source  = "transcend-io/fargate-container/aws"
-  version = "1.9.2"
+  source = "transcend-io/fargate-container/aws"
+  # Bumped from 1.9.2 to pick up `versionConsistency = "disabled"` on the
+  # rendered container definition, which prevents the failure mode where
+  # ECS pins an active deployment to an image digest that ECR's lifecycle
+  # policy later deletes. See transcend-io/terraform-aws-fargate-container#PR
+  # and the 2026-05-05 prod-multi-tenant-sombra-service incident for context.
+  version = "1.11.0"
 
   name           = "${var.deploy_env}-${var.project_id}-container"
   image          = var.ecr_image

--- a/main.tf
+++ b/main.tf
@@ -45,17 +45,25 @@ module "load_balancer" {
 
 module "container_definition" {
   source = "transcend-io/fargate-container/aws"
-  # Bumped from 1.9.2 to pick up `versionConsistency = "disabled"` on the
-  # rendered container definition, which prevents the failure mode where
-  # ECS pins an active deployment to an image digest that ECR's lifecycle
-  # policy later deletes. See transcend-io/terraform-aws-fargate-container#PR
-  # and the 2026-05-05 prod-multi-tenant-sombra-service incident for context.
+  # Bumped from 1.9.2 to gain support for the optional `version_consistency`
+  # passthrough variable. The default behavior is unchanged (the field is
+  # only rendered when callers explicitly set
+  # `var.sombra_container_version_consistency` on this module). See
+  # transcend-io/terraform-aws-fargate-container#PR for the upstream
+  # passthrough; the 2026-05-05 prod-multi-tenant-sombra-service incident
+  # is the original motivation for exposing this knob.
   version = "1.11.0"
 
   name           = "${var.deploy_env}-${var.project_id}-container"
   image          = var.ecr_image
   containerPorts = [var.internal_port, var.external_port]
   ssm_prefix     = var.project_id
+
+  # Forward the optional ECS `versionConsistency` value to the rendered
+  # container definition. Default is null, which means no field is
+  # rendered and the AWS default (deployment-pinned digest) applies — i.e.
+  # this is a no-op for any consumer that does not opt in.
+  version_consistency = var.sombra_container_version_consistency
 
   use_cloudwatch_logs = var.use_cloudwatch_logs
   log_configuration   = var.log_configuration

--- a/variables.tf
+++ b/variables.tf
@@ -478,3 +478,29 @@ variable "ssl_policy" {
   description = "The Security Policy to use for SSL on the load balancers"
   default     = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
 }
+variable "sombra_container_version_consistency" {
+  type        = string
+  default     = null
+  description = <<EOF
+Optional value forwarded to the embedded `transcend-io/fargate-container/aws`
+module's `version_consistency` input, which controls the ECS container
+definition's `versionConsistency` field on the rendered sombra app
+container. When null (the default), the field is not rendered and AWS's
+default behavior applies (ECS pins the resolved image digest for every task
+in the active deployment). Set to "disabled" to make ECS re-resolve the
+floating image tag on every task launch — useful when the upstream image
+is re-tagged frequently (e.g. ":prod") and ECR lifecycle rules may
+garbage-collect a digest while a deployment still references it.
+
+See:
+- https://docs.aws.amazon.com/AmazonECS/latest/developerguide/version-consistency.html
+- transcend-io/terraform-aws-fargate-container#PR (the upstream variable)
+
+Valid values: null, "enabled", "disabled".
+EOF
+
+  validation {
+    condition     = var.sombra_container_version_consistency == null || contains(["enabled", "disabled"], var.sombra_container_version_consistency)
+    error_message = "sombra_container_version_consistency must be null, \"enabled\", or \"disabled\"."
+  }
+}


### PR DESCRIPTION
> 🤖 Posted by Cursor on behalf of @dmattia

## Related Github Issues

- _[none]_ — driven by [EPD-22668 - Fetch fresh ECS task images by tag](https://linear.app/transcend/issue/EPD-22668/fetch-fresh-ecs-task-images-by-tag) on the Transcend side.

## Description

Add an optional `var.sombra_container_version_consistency` (string, default `null`) that is forwarded to the embedded `transcend-io/fargate-container/aws` module's matching `version_consistency` input. **No-op for any consumer that does not opt in** — when the variable is null, no field is rendered on the sombra app container definition and AWS's default ECS behavior applies.

This PR also bumps the inner `transcend-io/fargate-container/aws` pin from `1.9.2` → `1.11.0`, which is the version that introduces the upstream `version_consistency` passthrough variable. See [transcend-io/terraform-aws-fargate-container#30](https://github.com/transcend-io/terraform-aws-fargate-container/pull/30) for the upstream change.

### Why expose this

ECS [software version consistency](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/version-consistency.html) (default since November 2024) resolves a floating image tag to a digest at deployment time and pins every task launched by that deployment to that digest. If the originally-pinned digest is ever deleted from ECR (e.g. by an "untagged image" lifecycle rule reaping the digest after a `:prod` retag), every replacement task fails with `CannotPullContainerError: ... not found` until somebody runs `aws ecs update-service --force-new-deployment`.

This is the failure mode that took out `prod-multi-tenant-sombra-service` on 2026-05-05 — the sombra app container is rendered through the same `transcend-io/fargate-container/aws` chain as the vault-agent sidecar that broke, and is vulnerable to the same chain.

### Why opt-in (not the default)

This is a deployment-mechanics behavior change. Some Sombra consumers may genuinely prefer the AWS default — byte-identical image fleet within a deployment, no risk of mixed-version-fleet during scale-out. Defaulting the new variable to `null` (don't render the field) keeps every existing consumer's behavior identical to today's. Consumers that want fresh tag resolution opt in by setting `sombra_container_version_consistency = "disabled"` on the module call.

### Branching choice

PR base is `release/v1.8`, a branch I cut off the **`v1.8.3`** tag (latest `v1.x` release). Direct consumers in [transcend-io/main](https://github.com/transcend-io/main) currently pin `v1.8.0` / `v1.8.1`; jumping them to a `v1.8.4` patch keeps the upgrade surface tiny vs. moving them across the `v1.x → v2.x` boundary on `master`.

### Validation

`var.sombra_container_version_consistency` is constrained to one of `null`, `"enabled"`, or `"disabled"` via `validation { condition = ... }` so typos surface at plan time.

### After merge

Cut a new tag — proposed: **`v1.8.4`** (patch bump, contains only the inner-module bump + new opt-in variable on top of `v1.8.3`).

**Depends on:** [transcend-io/terraform-aws-fargate-container#30](https://github.com/transcend-io/terraform-aws-fargate-container/pull/30) merging and being tagged as `v1.11.0` before this PR can be tagged as `v1.8.4`.

## Security Implications

- _[none]_

## System Availability

**For Sombra consumers that don't opt in:** zero behavior change. The rendered sombra app container definition is byte-identical to today's.

**For consumers that opt in via `sombra_container_version_consistency = "disabled"`:** same trade-off as in the upstream PR — replacement tasks within an active ECS deployment may briefly run a newer image than tasks that started earlier in the same deployment.