### PR TITLE
feat: add extra_volumes and extra_sombra_container_mount_points inputs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@
 
 module "container_definition" {
   source  = "transcend-io/fargate-container/aws"
-  version = "1.10.0"
+  version = "1.11.0"
 
   name           = "${var.deploy_env}-${var.project_id}-container"
   image          = var.ecr_image
@@ -14,6 +14,8 @@ module "container_definition" {
   portNames = tomap({
     tostring(var.internal_port) = "internalSombra",
   })
+
+  version_consistency = var.sombra_container_version_consistency
 
   use_cloudwatch_logs = var.use_cloudwatch_logs
   log_configuration   = var.log_configuration
@@ -81,6 +83,8 @@ module "container_definition" {
     if try(length(val) > 0, false)
   }, var.extra_secret_envs)
 
+  mount_points = var.extra_sombra_container_mount_points
+
   deploy_env = var.deploy_env
   aws_region = var.aws_region
   tags       = var.tags
@@ -119,6 +123,8 @@ module "service" {
     length(var.roles_to_assume) > 0 ? [aws_iam_policy.aws_policy[0].arn] : [],
   )
   additional_task_policy_arns_count = 2 + length(var.extra_task_policy_arns) + (length(var.roles_to_assume) > 0 ? 1 : 0)
+
+  volumes = var.extra_volumes
 
   # Scaling configuration.
   desired_count                  = var.desired_count

--- a/variables.tf
+++ b/variables.tf
@@ -352,3 +352,63 @@ variable "tags" {
   description = "Tags to apply to all resources that support them"
   default     = {}
 }
+
+variable "sombra_container_version_consistency" {
+  type        = string
+  default     = null
+  description = <<EOF
+Optional value forwarded to the embedded `transcend-io/fargate-container/aws`
+module's `version_consistency` input, which controls the ECS container
+definition's `versionConsistency` field on the rendered sombra app
+container. When null (the default), the field is not rendered and AWS's
+default behavior applies (ECS pins the resolved image digest for every task
+in the active deployment). Set to "disabled" to make ECS re-resolve the
+floating image tag on every task launch — useful when the upstream image
+is re-tagged frequently (e.g. ":prod") and ECR lifecycle rules may
+garbage-collect a digest while a deployment still references it.
+
+Valid values: null, "enabled", "disabled".
+EOF
+
+  validation {
+    condition     = var.sombra_container_version_consistency == null || contains(["enabled", "disabled"], var.sombra_container_version_consistency)
+    error_message = "sombra_container_version_consistency must be null, \"enabled\", or \"disabled\"."
+  }
+}
+
+variable "extra_volumes" {
+  type        = list(map(string))
+  description = <<EOF
+  List of additional task-level ECS volumes to attach to the Sombra task definition.
+  Each entry is a map with a "name" key (and optionally "host_path" for bind-mount
+  volumes; omit host_path for ephemeral volumes).
+
+  Example (ephemeral seneca-run volume for OPA token-file sharing):
+    extra_volumes = [{ name = "seneca-run" }]
+
+  See: https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Volume.html
+  EOF
+  default     = []
+}
+
+variable "extra_sombra_container_mount_points" {
+  type = list(object({
+    sourceVolume  = string
+    containerPath = string
+    readOnly      = bool
+  }))
+  description = <<EOF
+  Additional mount points to attach to the Sombra container definition.
+  Each entry must reference a volume name defined in var.extra_volumes (or any
+  other volume already present in the task definition).
+
+  Example (mount the seneca-run volume read-write so Sombra can write the
+  OPA bundle token):
+    extra_sombra_container_mount_points = [{
+      sourceVolume  = "seneca-run"
+      containerPath = "/run/seneca"
+      readOnly      = false
+    }]
+  EOF
+  default = []
+}


### PR DESCRIPTION
## Related Issues

- https://linear.app/transcend/issue/LINK-6927/bump-terraform-aws-sombra-terraform-aws-fargate-container-to-support

## Description

Exposes two new optional variables so callers can wire task-level ECS volumes and per-container mount points without forking the module:

- `extra_volumes` (`list(map(string))`, default `[]`) — forwarded to the fargate-service module's `volumes` input; adds named volumes to the ECS task definition (e.g. an ephemeral `seneca-run` volume for sidecar file sharing).
- `extra_sombra_container_mount_points` (`list(object)`, default `[]`) — forwarded to the fargate-container module's `mount_points` input on the Sombra container definition.

Both default to empty so existing callers are unaffected.

Needed by `transcend-io/main` infra/sombra to wire the `seneca-run` ephemeral volume between the Sombra container (rw) and the OPA sidecar (ro) for the LINK-6815 bundle-token handshake.

## Security Implications

- _[none]_

## System Availability

- _[none]_
