### PR TITLE
🤖🔵 Expose ALB health check timeout

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,7 @@ module "load_balancer" {
 
   # Health check settings
   health_check_protocol = var.health_check_protocol
+  health_check_timeout  = var.health_check_timeout
 
   # Ports and Firewall settings
   internal_port         = var.internal_port

--- a/modules/sombra_load_balancers/separate_albs.tf
+++ b/modules/sombra_load_balancers/separate_albs.tf
@@ -2,7 +2,7 @@
 # Internal, Private Load Balancer #
 ###################################
 
-module internal_load_balancer {
+module "internal_load_balancer" {
   source  = "terraform-aws-modules/alb/aws"
   version = "5.10.0"
 
@@ -48,6 +48,7 @@ module internal_load_balancer {
     health_check = {
       enabled  = true
       interval = 30
+      timeout  = var.health_check_timeout
       port     = var.internal_port
       path     = "/health"
       protocol = var.health_check_protocol
@@ -116,7 +117,7 @@ resource "aws_route53_record" "alb_alias" {
 # External, Transcend Facing Load Balancer #
 ############################################
 
-module external_load_balancer {
+module "external_load_balancer" {
   source  = "terraform-aws-modules/alb/aws"
   version = "5.10.0"
 
@@ -148,6 +149,7 @@ module external_load_balancer {
     health_check = {
       enabled  = true
       interval = 30
+      timeout  = var.health_check_timeout
       port     = var.external_port
       path     = "/health"
       protocol = var.health_check_protocol

--- a/modules/sombra_load_balancers/single_alb.tf
+++ b/modules/sombra_load_balancers/single_alb.tf
@@ -53,6 +53,7 @@ module "load_balancer" {
       health_check = {
         enabled  = true
         interval = 30
+        timeout  = var.health_check_timeout
         port     = var.internal_port
         path     = "/health"
         protocol = var.health_check_protocol
@@ -67,6 +68,7 @@ module "load_balancer" {
       health_check = {
         enabled  = true
         interval = 30
+        timeout  = var.health_check_timeout
         port     = var.external_port
         path     = "/health"
         protocol = var.health_check_protocol

--- a/modules/sombra_load_balancers/variables.tf
+++ b/modules/sombra_load_balancers/variables.tf
@@ -1,4 +1,4 @@
-variable use_private_load_balancer {
+variable "use_private_load_balancer" {
   type        = bool
   description = <<EOF
   If true, the internal load balancer will not have publically accessible DNS.
@@ -9,7 +9,7 @@ variable use_private_load_balancer {
   EOF
 }
 
-variable use_network_load_balancer {
+variable "use_network_load_balancer" {
   type        = bool
   description = <<EOF
   If true, the internal load balancer will use a Network Load Balancer instead of an Application Load Balancer.
@@ -17,14 +17,14 @@ variable use_network_load_balancer {
   Use this if you plan to terminate SSL on the sombra itself, and not on the load balancer. This should always be
   used with `tls_config` on the root module.
   EOF
-  default = false
+  default     = false
 }
 
-variable deploy_env {
+variable "deploy_env" {
   description = "The environment to deploy to, usually dev, staging, or prod"
 }
 
-variable project_id {
+variable "project_id" {
   description = "A name to use in resources, such as the name of your company."
 }
 
@@ -34,27 +34,27 @@ variable "alb_access_logs" {
   default     = {}
 }
 
-variable certificate_arn {
+variable "certificate_arn" {
   description = "Arn of the ACM cert that exists on the ALB"
 }
 
-variable internal_port {
+variable "internal_port" {
   description = "The port the internal sombra should run on. This is the server that your internal services will have access to."
   default     = 443
 }
 
-variable external_port {
+variable "external_port" {
   description = "The port the external sombra should run on, this is the server that only Transcend's API talks to."
   default     = 5041
 }
 
-variable transcend_backend_ips {
+variable "transcend_backend_ips" {
   type        = list(string)
   default     = ["52.215.231.215/32", "63.34.48.255/32", "34.249.254.13/32", "54.75.178.77/32"]
   description = "The IP addresses of Transcend"
 }
 
-variable incoming_cidr_ranges {
+variable "incoming_cidr_ranges" {
   type        = list(string)
   description = <<EOF
   If you want to restrict the IP addresses that can talk to the
@@ -66,26 +66,26 @@ variable incoming_cidr_ranges {
   default     = ["0.0.0.0/0"]
 }
 
-variable vpc_id {
+variable "vpc_id" {
   description = "The ID of the VPC to put the load balancer(s) into"
 }
 
-variable public_subnet_ids {
+variable "public_subnet_ids" {
   type        = list(string)
   description = "The subnets the external ALB can be placed into"
 }
 
-variable private_subnet_ids {
+variable "private_subnet_ids" {
   type        = list(string)
   description = "The subnets the ECS tasks can be placed into, as well as the internal load balancer if desired"
 }
 
-variable private_subnets_cidr_blocks {
+variable "private_subnets_cidr_blocks" {
   type        = list(string)
   description = "CIDR blocks that an ECS task could be in"
 }
 
-variable subdomain {
+variable "subdomain" {
   description = <<EOF
   The subdomain to create the sombra services at.
 
@@ -94,7 +94,7 @@ variable subdomain {
   EOF
 }
 
-variable root_domain {
+variable "root_domain" {
   description = <<EOF
   The root domain to create the sombra services at.
 
@@ -103,19 +103,19 @@ variable root_domain {
   EOF
 }
 
-variable zone_id {
+variable "zone_id" {
   description = "The ID of the Route53 hosted zone where the public sombra subdomain will be created"
 }
 
-variable override_alb_name {
+variable "override_alb_name" {
   type        = string
   default     = null
   description = "If set as a string, this custom name will be used on the alb resources"
 }
 
 variable "idle_timeout" {
-  type = number
-  default = 60
+  type        = number
+  default     = 60
   description = "The time in seconds that the connection is allowed to be idle"
 }
 
@@ -125,13 +125,19 @@ variable "health_check_protocol" {
   default     = "HTTPS"
 }
 
+variable "health_check_timeout" {
+  type        = number
+  description = "The amount of time, in seconds, the ALB waits for a /health response before considering a single health check a failure. Must be less than the 30s health check interval."
+  default     = 5
+}
+
 variable "ssl_policy" {
   type        = string
   description = "The Security Policy to use for SSL on the load balancers"
   default     = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
 }
 
-variable tags {
+variable "tags" {
   type        = map(string)
   description = "Tags to apply to all resources that support them"
   default     = {}

--- a/variables.tf
+++ b/variables.tf
@@ -467,6 +467,21 @@ variable "health_check_protocol" {
   default     = "HTTPS"
 }
 
+variable "health_check_timeout" {
+  type        = number
+  description = <<EOF
+  The amount of time, in seconds, the ALB waits for a `/health` response before
+  considering a single health check a failure. Must be less than the (fixed) 30s
+  health check interval.
+
+  The default of 5 matches the previous AWS default. Raise this for services whose
+  event loop can be briefly blocked by slow synchronous/native work (e.g. ODBC
+  queries to slow customer databases) so transient stalls don't fail health checks
+  and trigger task replacement.
+  EOF
+  default     = 5
+}
+
 variable "roles_to_assume" {
   type        = list(string)
   description = "AWS IAM Roles that sombra can assume, used in AWS integrations"


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- _[none]_

## Description

Adds a new `health_check_timeout` input that is passed from the root Sombra module into the load-balancer submodule and wired into both internal and external ALB target-group `/health` checks.

The default remains `5`, matching the previous AWS default behavior. Consumers can now opt into a larger timeout (for example, 15–20 seconds) without forking the module or modifying target groups out-of-band. This is intended to support a `v1.8.5` patch release for existing `v1.8.x` consumers.

Linear context: [LAK-2397 - Investigate Multi-Tenant Sombra latency spikes in eu-west-1](https://linear.app/transcend/issue/LAK-2397/investigate-multi-tenant-sombra-latency-spikes-in-eu-west-1)

Validation:

- `terraform fmt -check main.tf variables.tf modules/sombra_load_balancers/single_alb.tf modules/sombra_load_balancers/separate_albs.tf modules/sombra_load_balancers/variables.tf`
- `terraform init -backend=false -input=false`
- `terraform validate`

## Security Implications

- _[none]_

## System Availability

- Allows callers to raise the ALB `/health` timeout to avoid replacing otherwise healthy tasks during transient event-loop stalls. Default behavior is unchanged unless a caller sets the new input.

Made with [Cursor](https://cursor.com)